### PR TITLE
Register bash.foo.ng

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -1,6 +1,7 @@
 {
     "a": "192.168.5.20",
     "ab": "192.168.5.20",
+    "bash": "browserbash.vercel.app",
     "botanybase": "botanybase.github.io",
     "codersplanet": "codersplanet.vercel.app",
     "dmzartchive": "128.204.218.48",


### PR DESCRIPTION
Linking to browserbash.vercel.app

Could you please "Set the following TXT record on _vercel.foo.ng to use bash.foo.ng in this project. Once the verification is completed and the domain is successfully configured, the TXT record can be removed.

Type
TXT

Name
_vercel

Value
vc-domain-verify=bash.foo.ng,be65baad7aa92ea4d0aa "
Thanks, Hazel
