### PR TITLE
Add project-integration.foo.ng

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -39,6 +39,7 @@
     "pi": "10.0.0.2",
     "pnsgos": "shoknt.github.io",
     "powerguilds": "power-guilds.pages.dev",
+    "project-integration": "138.199.207.53",
     "reha": "rreha.github.io",
     "rewardify": "nskcheats.github.io",
     "rplzi6anzu7w": "gv-pdhnqomhtly3wu.dv.googlehosted.com",


### PR DESCRIPTION
Thank you for providing such useful service!

I need to host a webapp for a university project for about 2-3 months.

I don't have any attachment to this particular domain name and will be happy to change it if it's e.g. too generic.