### PR TITLE
For two subdomains: 5chan.foo.ng, anw.foo.ng

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -1,4 +1,5 @@
 {
+    "5chan": "5chan-vercel.vercel.app",
     "a": "192.168.5.20",
     "ab": "192.168.5.20",
     "abhi": "abhi-maybe.vercel.app",
@@ -6,6 +7,7 @@
     "aj-websocket": "193.30.121.75",
     "akio": "akio-website.vercel.app",
     "amethyst": "32.216.183.113",
+    "anw": "anw-site.vercel.app",
     "arjun": "arjunaa.netlify.app",
     "bar": "xanderplayz16-school.github.io",
     "bash": "browserbash.vercel.app",


### PR DESCRIPTION
Hi, I am Subhrajit or ANW.
I wish to have these two subdomains: `5chan.foo.ng` and `anw.foo.ng`.

Here are the required TXT records from vercel:
**5chan:**
```
vc-domain-verify=5chan.foo.ng,2eef582541c76f9a395f
```
**ANW:**
```
vc-domain-verify=anw.foo.ng,2bc3a64346f13d564855
```

Hope this is enough information.
Thank you.