### PR TITLE
godiscord.foo.ng

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -24,6 +24,7 @@
     "fauqi": "fauqi.vercel.app",
     "fiftyfive": "fiftyfive-foo-ng.vercel.app",
     "fpl": "129.154.192.67",
+    "godiscord": "godiscord.vercel.app",
     "hosted": "154.38.167.39",
     "intelligent": "intelligent-documentation.vercel.app",
     "internal.powerguilds": "69.30.249.53",


### PR DESCRIPTION
Hi!
I'm currently working on a Go library to make Discord bots, and I'd like to have the `godiscord.foo.ng` domain to prevent users from typing only "github.com/AYn0nyme/godiscord" and to host the docs later

Here is the TXT Record:
```
vc-domain-verify=godiscord.foo.ng,2423ea4edb54b150e508
```
Thanks!