### PR TITLE
ribbon.foo.ng

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -54,6 +54,7 @@
     "project-integration": "138.199.207.53",
     "reha": "rreha.github.io",
     "rewardify": "nskcheats.github.io",
+    "ribbon": "ribbon-eight.vercel.app",
     "rplzi6anzu7w": "gv-pdhnqomhtly3wu.dv.googlehosted.com",
     "s-qqqw": "cmcm-bkz.pages.dev",
     "santii": "santii.vercel.app",


### PR DESCRIPTION
Hello, I'm working on a hobby project called ribbon that allows users to create custom messages with twist of challenges in a silly way. I'd like to have a `ribbon.foo.ng` domain so it's shorter and easy to type.

Here's the TXT Record:
```
vc-domain-verify=ribbon.foo.ng,db0f0c86f8fb390b36a0
```