### PR TITLE
Add lrclib.foo.ng

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -48,6 +48,7 @@
     "livetvlk": "38f9ugvvgo67o.ahost.marscode.site",
     "loganpaxton": "loganpaxton-pages-dev.pages.dev",
     "loopbreaker": "axelvyrn.github.io",
+    "lrclib": "lrclib-js-website.vercel.app",
     "maat": "147.185.221.28",
     "massroom": "massroom.github.io",
     "matthew": "mjuch.codeberg.page",


### PR DESCRIPTION
This is a web client for https://lrclib.net API showcasing the usage of a js library `lrclib.js`

### TXT
```
vc-domain-verify=lrclib.foo.ng,9baa29aea51e837e0e40
```