### PR TITLE
Add new subdomain entry for Qwink

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -96,7 +96,7 @@
     "pnsgos": "shoknt.github.io",
     "project-integration": "138.199.207.53",
     "pxl": "heypxl.github.io",
-    "q": "subhrajitsain2.pythonanywhere.com",
+    "q": "edge.redirect.pizza",
     "r": "raster.pages.dev",
     "radioplay": "radioplay.pages.dev",
     "random-things-on-internet": "45.14.194.247",

--- a/subdomains.json
+++ b/subdomains.json
@@ -96,6 +96,7 @@
     "pnsgos": "shoknt.github.io",
     "project-integration": "138.199.207.53",
     "pxl": "heypxl.github.io",
+    "q": "subhrajitsain2.pythonanywhere.com",
     "r": "raster.pages.dev",
     "radioplay": "radioplay.pages.dev",
     "random-things-on-internet": "45.14.194.247",


### PR DESCRIPTION
Hi Pokymon,
I need this subdomain for my URL shortener, Qwink at https://subhrajitsain2.pythonanywhere.com/. Do you support URL and path/route redirection or are URL-shorteners allowed by you?
By redirection, I mean: 
1. `q.foo.ng` -> `https://subhrajitsain2.pythonanywhere.com`
2. `q.foo.ng/abc123` -> `https://subhrajitsain2.pythonanywhere.com/abc123`

Please let me know if you support them.
Thank you,
ANW.