### PR TITLE
Add new subdomain entry for 'riwen'

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -1,4 +1,5 @@
 {
+    "riwen" : "interverti.fr",
     "5chan": "5chan-vercel.vercel.app",
     "a": "192.168.5.20",
     "ab": "192.168.5.20",


### PR DESCRIPTION
Adding the subdomain `riwen.foo.ng`, which redirects to my personal portfolio interverti.fr (CNAME).

The site is my developer portfolio (Java/TypeScript): it showcases my technical skills, my projects (including Minecraft plugins for Paper/Spigot), and links to related friend subdomains/projects.

Not using Vercel, so no TXT record needs to be provided.