### PR TITLE
Add raylauncher subdomain

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -160,5 +160,6 @@
     "zdv3": "45.197.147.243",
     "zethsu": "zethsu.vercel.app",
     "zitacode": "zita-code.vercel.app",
-    "zk": "0226b0240bae90b4.vercel-dns-017.com"
+    "zk": "0226b0240bae90b4.vercel-dns-017.com",
+    "raylauncher": "vibeoptimist.github.io"
 }


### PR DESCRIPTION
Adding subdomain for RayLauncher — a Minecraft launcher landing page, hosted on GitHub Pages.