### PR TITLE
Add eaglecropcarepvtltd subdomain

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -39,6 +39,7 @@
     "dot": "94.177.48.8",
     "duo": "10.0.0.4",
     "durokotte": "linuxfandudeguy.github.io",
+    "eaglecropcarepvtltd": "ace4d836b9493da7.vercel-dns-017.com",
     "easylua": "easydotlua.vercel.app",
     "easyt": "easytransfer-zeta.vercel.app",
     "erp": "116.63.178.245",


### PR DESCRIPTION
Requesting the following free subdomain:

Subdomain: eaglecropcarepvtltd.foo.ng
Hosting provider: Vercel

CNAME target:
ace4d836b9493da7.vercel-dns-017.com

Vercel domain ownership verification TXT record:
vc-domain-verify=eaglecropcarepvtltd.foo.ng,6bdd3a00ce2cffff25fb

The subdomain has already been added to the Vercel project and is currently awaiting DNS verification/configuration.

Thank you!