### PR TITLE
Add ml.foo.ng

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -100,6 +100,7 @@
     "mayo": "45.90.123.50",
     "mcknifemaker": "martincampanella-lab.github.io",
     "mindease": "mindease-project.vercel.app",
+    "ml": "wegiel360.github.io",
     "monodex": "99f6ab229088b8a2.vercel-dns-017.com",
     "movie": "seriesonline.ac",
     "myferr": "myferr.vercel.app",


### PR DESCRIPTION
Dodaję subdomenę **ml.foo.ng** jako rekord CNAME na **wegiel360.github.io** (GitHub Pages).

**O projekcie:** Masło Lab — system zamówień wydruków 3D dla społeczności szkolnej (strona sklepowa z ofertami, koszykiem i śledzeniem zamówień). Aplikacja kliencka napisana w czystym JavaScripcie (vanilla JS, Firestore, Three.js), hostowana na GitHub Pages.

Dzięki!