### PR TITLE
Add dsl subdomain

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -40,6 +40,7 @@
     "dart": "15.235.181.164",
     "dmzartchive": "128.204.218.48",
     "dot": "94.177.48.8",
+    "dsl": "dsl-status.aiclub.anu.edu.in",
     "duo": "10.0.0.4",
     "durokotte": "linuxfandudeguy.github.io",
     "eaglecropcarepvtltd": "ace4d836b9493da7.vercel-dns-017.com",


### PR DESCRIPTION
**Subdomain:** `dsl.foo.ng`
**Record type:** CNAME
**Target:** `dsl-status.aiclub.anu.edu.in`

A course tool for a class of sixty-three interaction-design students at Anant National University. They write one line a day against the day's question and read what everyone else wrote. Self-hosted on our own server; the short name is so the students have something they can type from memory.

Not Vercel, Netlify or Cloudflare Workers — a plain Node app behind our own reverse proxy, so no TXT record is needed.