### PR TITLE
Add new subdomain entry for 'ssmarve'

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -188,5 +188,6 @@
     "zdv3": "45.197.147.243",
     "zethsu": "zethsu.vercel.app",
     "zitacode": "zita-code.vercel.app",
-    "zk": "0226b0240bae90b4.vercel-dns-017.com"
+    "zk": "0226b0240bae90b4.vercel-dns-017.com",
+    "ssmarve": "2b454bc42ca52f72.vercel-dns-017.com."
 }

--- a/subdomains.json
+++ b/subdomains.json
@@ -189,5 +189,5 @@
     "zethsu": "zethsu.vercel.app",
     "zitacode": "zita-code.vercel.app",
     "zk": "0226b0240bae90b4.vercel-dns-017.com",
-    "ssmarve": "2b454bc42ca52f72.vercel-dns-017.com."
+    "ssmarve": "2b454bc42ca52f72.vercel-dns-017.com"
 }


### PR DESCRIPTION
I would like to claim ssmarve.foo.ng for an anonymous college confession page.

Vercel verification record:

Type: TXT
Name: _vercel
Value: vc-domain-verify=ssmarve.foo.ng,263c5d697fe1e96cadee