### PR TITLE
Add demo subdomain

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -40,6 +40,7 @@
     "crown": "royal-server.github.io",
     "crown-cdn": "royal-server.github.io",
     "dart": "15.235.181.164",
+    "demo": "207.231.107.57",
     "dmzartchive": "128.204.218.48",
     "dot": "94.177.48.8",
     "duo": "10.0.0.4",


### PR DESCRIPTION
Add demo subdomain pointing to 207.231.107.57 for the bioDZ platform demonstration.