### PR TITLE
Add lvieux.foo.ng subdomain

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -93,7 +93,7 @@
     "literallyblue": "1770623-eng.github.io",
     "liu": "cname.tony-liu.com",
     "livetvlk": "38f9ugvvgo67o.ahost.marscode.site",
-    "lvieux": "fb7ff91dff6abee2.vercel-dns-017.com.",
+    "lvieux": "fb7ff91dff6abee2.vercel-dns-017.com",
     "loganpaxton": "loganpaxton-pages-dev.pages.dev",
     "loichuango": "ns1.desec.io",
     "loopbreaker": "axelvyrn.github.io",

--- a/subdomains.json
+++ b/subdomains.json
@@ -93,6 +93,7 @@
     "literallyblue": "1770623-eng.github.io",
     "liu": "cname.tony-liu.com",
     "livetvlk": "38f9ugvvgo67o.ahost.marscode.site",
+    "lvieux": "fb7ff91dff6abee2.vercel-dns-017.com.",
     "loganpaxton": "loganpaxton-pages-dev.pages.dev",
     "loichuango": "ns1.desec.io",
     "loopbreaker": "axelvyrn.github.io",


### PR DESCRIPTION
## Subdomain Request

I would like to register:

- Subdomain: lvieux.foo.ng
- Project: LVIEUX fashion storefront
- Hosting provider: Vercel
- Record type: CNAME
- Target: fb7ff91dff6abee2.vercel-dns-017.com.

The LVIEUX project is hosted at:

https://lvieux.vercel.app

Vercel TXT verification record:

vc-domain-verify=lvieux.foo.ng,ba29060d603afdee870f

IMPORTANT:
- Use the TXT value exactly as provided.
- Do not modify or shorten it.
- Follow the current foo.ng README exactly.
- Do not modify any LVIEUX application files.
- Do not touch lvieux.qd.je.